### PR TITLE
build(deps-dev): bump group with 4 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,13 +53,13 @@
       },
       "devDependencies": {
         "changelog-light": "^1.2.0",
-        "cspell": "^8.8.3",
+        "cspell": "^8.8.4",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-jest": "^28.5.0",
-        "eslint-plugin-jsdoc": "^48.2.7",
+        "eslint-plugin-jest": "^28.6.0",
+        "eslint-plugin-jsdoc": "^48.2.12",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
@@ -67,7 +67,7 @@
         "lodash": "^4.17.21",
         "npm-check-updates": "^16.14.20",
         "npm-run-all": "^4.1.5",
-        "prettier": "^3.3.0"
+        "prettier": "^3.3.2"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -1821,16 +1821,16 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.3.tgz",
-      "integrity": "sha512-nRa30TQwE4R5xcM6CBibM2l7D359ympexjm7OrykzYmStIiiudDIsuNOIXGBrDouxRFgKGAa/ETo1g+Pxz7kNA==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.4.tgz",
+      "integrity": "sha512-k9ZMO2kayQFXB3B45b1xXze3MceAMNy9U+D7NTnWB1i3S0y8LhN53U9JWWgqHGPQaHaLHzizL7/w1aGHTA149Q==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
         "@cspell/dict-aws": "^4.0.2",
         "@cspell/dict-bash": "^4.1.3",
-        "@cspell/dict-companies": "^3.1.0",
-        "@cspell/dict-cpp": "^5.1.6",
+        "@cspell/dict-companies": "^3.1.2",
+        "@cspell/dict-cpp": "^5.1.8",
         "@cspell/dict-cryptocurrencies": "^5.0.0",
         "@cspell/dict-csharp": "^4.0.2",
         "@cspell/dict-css": "^4.0.12",
@@ -1839,7 +1839,7 @@
         "@cspell/dict-docker": "^1.1.7",
         "@cspell/dict-dotnet": "^5.0.2",
         "@cspell/dict-elixir": "^4.0.3",
-        "@cspell/dict-en_us": "^4.3.20",
+        "@cspell/dict-en_us": "^4.3.21",
         "@cspell/dict-en-common-misspellings": "^2.0.1",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.4",
@@ -1849,13 +1849,13 @@
         "@cspell/dict-gaming-terms": "^1.0.5",
         "@cspell/dict-git": "^3.0.0",
         "@cspell/dict-golang": "^6.0.9",
-        "@cspell/dict-google": "^1.0.0",
+        "@cspell/dict-google": "^1.0.1",
         "@cspell/dict-haskell": "^4.0.1",
         "@cspell/dict-html": "^4.0.5",
         "@cspell/dict-html-symbol-entities": "^4.0.0",
         "@cspell/dict-java": "^5.0.6",
         "@cspell/dict-julia": "^1.0.1",
-        "@cspell/dict-k8s": "^1.0.3",
+        "@cspell/dict-k8s": "^1.0.5",
         "@cspell/dict-latex": "^4.0.0",
         "@cspell/dict-lorem-ipsum": "^4.0.0",
         "@cspell/dict-lua": "^4.0.3",
@@ -1865,13 +1865,13 @@
         "@cspell/dict-npm": "^5.0.16",
         "@cspell/dict-php": "^4.0.7",
         "@cspell/dict-powershell": "^5.0.4",
-        "@cspell/dict-public-licenses": "^2.0.6",
+        "@cspell/dict-public-licenses": "^2.0.7",
         "@cspell/dict-python": "^4.1.11",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^5.0.2",
         "@cspell/dict-rust": "^4.0.3",
         "@cspell/dict-scala": "^5.0.2",
-        "@cspell/dict-software-terms": "^3.3.23",
+        "@cspell/dict-software-terms": "^3.4.1",
         "@cspell/dict-sql": "^2.1.3",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
@@ -1884,30 +1884,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.8.3.tgz",
-      "integrity": "sha512-XP8x446IO9iHKvEN1IrJwOC5wC2uwmbdgFiUiXfzPSAlPfRWBmzOR68UR0Z6LNpm1GB4sUxxQkx2CRqDyGaSng==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.8.4.tgz",
+      "integrity": "sha512-ITpOeNyDHD+4B9QmLJx6YYtrB1saRsrCLluZ34YaICemNLuumVRP1vSjcdoBtefvGugCOn5nPK7igw0r/vdAvA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.8.3"
+        "@cspell/cspell-types": "8.8.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.3.tgz",
-      "integrity": "sha512-tzngpFKXeUsdTZEErffTlwUnPIKYgyRKy0YTrD77EkhyDSbUnaS8JWqtGZbKV7iQ+R4CL7tiaubPjUzkbWj+kQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.4.tgz",
+      "integrity": "sha512-Uis9iIEcv1zOogXiDVSegm9nzo5NRmsRDsW8CteLRg6PhyZ0nnCY1PZIUy3SbGF0vIcb/M+XsdLSh2wOPqTXww==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.3.tgz",
-      "integrity": "sha512-pMOB2MJYeria0DeW1dsehRPIHLzoOXCm1Cdjp1kRZ931PbqNCYaE/GM6laWpUTAbS9Ly2tv4g0jK3PUH8ZTtJA==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.4.tgz",
+      "integrity": "sha512-eZVw31nSeh6xKl7TzzkZVMTX/mgwhUw40/q1Sqo7CTPurIBg66oelEqKRclX898jzd2/qSK+ZFwBDxvV7QH38A==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -1917,18 +1917,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.3.tgz",
-      "integrity": "sha512-QVKe/JZvoTaaBAMXG40HjZib1g6rGgxk03e070GmdfCiMRUCWFtK+9DKVYJfSqjQhzj/eDCrq8aWplHWy66umg==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.4.tgz",
+      "integrity": "sha512-KtwJ38uPLrm2Q8osmMIAl2NToA/CMyZCxck4msQJnskdo30IPSdA1Rh0w6zXinmh1eVe0zNEVCeJ2+x23HqW+g==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.3.tgz",
-      "integrity": "sha512-31wYSBPinhqKi9TSzPg50fWHJmMQwD1d5p26yM/NAfNQvjAfBQlrg4pqix8pxOJkAK5W/TnoaVXjzJ5XCg6arQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.4.tgz",
+      "integrity": "sha512-ya9Jl4+lghx2eUuZNY6pcbbrnResgEAomvglhdbEGqy+B5MPEqY5Jt45APEmGqHzTNks7oFFaiTIbXYJAFBR7A==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -1959,9 +1959,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.8.tgz",
-      "integrity": "sha512-X5uq0uRqN6cyOZOZV1YKi6g8sBtd0+VoF5NbDWURahGR8TRsiztH0sNqs0IB3X0dW4GakU+n9SXcuEmxynkSsw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.9.tgz",
+      "integrity": "sha512-lZmPKn3qfkWQ7tr+yw6JhuhscsyRgRHEOpOd0fhtPt0N154FNsGebGGLW0SOZUuGgW7Nk3lCCwHP85GIemnlqQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
@@ -1989,9 +1989,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-data-science": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-1.0.11.tgz",
-      "integrity": "sha512-TaHAZRVe0Zlcc3C23StZqqbzC0NrodRwoSAc8dis+5qLeLLnOCtagYQeROQvDlcDg3X/VVEO9Whh4W/z4PAmYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.1.tgz",
+      "integrity": "sha512-xeutkzK0eBe+LFXOFU2kJeAYO6IuFUc1g7iRLr7HeCmlC4rsdGclwGHh61KmttL3+YHQytYStxaRBdGAXWC8Lw==",
       "dev": true
     },
     "node_modules/@cspell/dict-django": {
@@ -2103,9 +2103,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-java": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.6.tgz",
-      "integrity": "sha512-kdE4AHHHrixyZ5p6zyms1SLoYpaJarPxrz8Tveo6gddszBVVwIUZ+JkQE1bWNLK740GWzIXdkznpUfw1hP9nXw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.7.tgz",
+      "integrity": "sha512-ejQ9iJXYIq7R09BScU2y5OUGrSqwcD+J5mHFOKbduuQ5s/Eh/duz45KOzykeMLI6KHPVxhBKpUPBWIsfewECpQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-julia": {
@@ -2163,9 +2163,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.7.tgz",
-      "integrity": "sha512-SUCOBfRDDFz1E2jnAZIIuy8BNbCc8i+VkiL9g4HH9tTN6Nlww5Uz2pMqYS6rZQkXuubqsbkbPlsRiuseEnTmYA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.8.tgz",
+      "integrity": "sha512-TBw3won4MCBQ2wdu7kvgOCR3dY2Tb+LJHgDUpuquy3WnzGiSDJ4AVelrZdE1xu7mjFJUr4q48aB21YT5uQqPZA==",
       "dev": true
     },
     "node_modules/@cspell/dict-powershell": {
@@ -2181,12 +2181,12 @@
       "dev": true
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.1.11.tgz",
-      "integrity": "sha512-XG+v3PumfzUW38huSbfT15Vqt3ihNb462ulfXifpQllPok5OWynhszCLCRQjQReV+dgz784ST4ggRxW452/kVg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.1.tgz",
+      "integrity": "sha512-9X2jRgyM0cxBoFQRo4Zc8oacyWnXi+0/bMI5FGibZNZV4y/o9UoFEr6agjU260/cXHTjIdkX233nN7eb7dtyRg==",
       "dev": true,
       "dependencies": {
-        "@cspell/dict-data-science": "^1.0.11"
+        "@cspell/dict-data-science": "^2.0.1"
       }
     },
     "node_modules/@cspell/dict-r": {
@@ -2202,9 +2202,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.3.tgz",
-      "integrity": "sha512-8DFCzkFQ+2k3fDaezWc/D+0AyiBBiOGYfSDUfrTNU7wpvUvJ6cRcAUshMI/cn2QW/mmxTspRgVlXsE6GUMz00Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.4.tgz",
+      "integrity": "sha512-v9/LcZknt/Xq7m1jdTWiQEtmkVVKdE1etAfGL2sgcWpZYewEa459HeWndNA0gfzQrpWX9sYay18mt7pqClJEdA==",
       "dev": true
     },
     "node_modules/@cspell/dict-scala": {
@@ -2214,9 +2214,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.0.tgz",
-      "integrity": "sha512-RfrSrvKBaUZ1q3R6eksWe+SMUDNFzAthqXGJuZeylZBO3LdaYdhRDcqFzeMwksfCYjvBYeJ1Ady6NSpdXzESjQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.6.tgz",
+      "integrity": "sha512-Cap+WL4iM9NgwxdVIa93aDEGKGNm1t+DLJTnjoWkGHXxSBPG8Kcbnlss6mTtwLv9/NYPmQsmJi5qHXruuHx2ow==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
@@ -2256,9 +2256,9 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.3.tgz",
-      "integrity": "sha512-qpxGC2hGVfbSaLJkaEu//rqbgAOjYnMlbxD75Fk9ny96sr+ZI1YC0nmUErWlgXSbtjVY/DHCOu26Usweo5iRgA==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.4.tgz",
+      "integrity": "sha512-tseSxrybznkmsmPaAB4aoHB9wr8Q2fOMIy3dm+yQv+U1xj+JHTN9OnUvy9sKiq0p3DQGWm/VylgSgsYaXrEHKQ==",
       "dev": true,
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.3.tgz",
-      "integrity": "sha512-y/pL7Zex8iHQ54qDYvg9oCiCgfZ9DAUTOI/VtPFVC+42JqLx6YufYxJS2uAsFlfAXIPiRV8qnnG6BHImD1Ix6g==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.4.tgz",
+      "integrity": "sha512-gticEJGR6yyGeLjf+mJ0jZotWYRLVQ+J0v1VpsR1nKnXTRJY15BWXgEA/ifbU/+clpyCek79NiCIXCvmP1WT4A==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -6586,22 +6586,22 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.8.3.tgz",
-      "integrity": "sha512-JVWI4MNALOuZ+igyJ54C6Iwe8s1ecMCgyGFGId5a0P6wi/V+TFYFhl7QkzIi1Uw4KtXSYrUSlHGUjC2dE0OZ9g==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.8.4.tgz",
+      "integrity": "sha512-eRUHiXvh4iRapw3lqE1nGOEAyYVfa/0lgK/e34SpcM/ECm4QuvbfY7Yl0ozCbiYywecog0RVbeJJUEYJTN5/Mg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.8.3",
-        "@cspell/cspell-pipe": "8.8.3",
-        "@cspell/cspell-types": "8.8.3",
-        "@cspell/dynamic-import": "8.8.3",
+        "@cspell/cspell-json-reporter": "8.8.4",
+        "@cspell/cspell-pipe": "8.8.4",
+        "@cspell/cspell-types": "8.8.4",
+        "@cspell/dynamic-import": "8.8.4",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-gitignore": "8.8.3",
-        "cspell-glob": "8.8.3",
-        "cspell-io": "8.8.3",
-        "cspell-lib": "8.8.3",
+        "cspell-gitignore": "8.8.4",
+        "cspell-glob": "8.8.4",
+        "cspell-io": "8.8.4",
+        "cspell-lib": "8.8.4",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^8.0.0",
@@ -6622,28 +6622,28 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.3.tgz",
-      "integrity": "sha512-61NKZrzTi9OLEEiZBggLQy9nswgR0gd6bKH06xXFQyRfNpAjaPOzOUFhSSfX1MQX+lQF3KtSYcHpppwbpPsL8w==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.4.tgz",
+      "integrity": "sha512-Xf+aL669Cm+MYZTZULVWRQXB7sRWx9qs0hPrgqxeaWabLUISK57/qwcI24TPVdYakUCoud9Nv+woGi5FcqV5ZQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.8.3",
+        "@cspell/cspell-types": "8.8.4",
         "comment-json": "^4.2.3",
-        "yaml": "^2.4.2"
+        "yaml": "^2.4.3"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.3.tgz",
-      "integrity": "sha512-g2G3uh8JbuJKAYFdFQENcbTIrK9SJRXBiQ/t+ch+9I/t5HmuGOVe+wxKEM/0c9M2CRLpzJShBvttH9rnw4Yqfg==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.4.tgz",
+      "integrity": "sha512-eDi61MDDZycS5EASz5FiYKJykLEyBT0mCvkYEUCsGVoqw8T9gWuWybwwqde3CMq9TOwns5pxGcFs2v9RYgtN5A==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.3",
-        "@cspell/cspell-types": "8.8.3",
-        "cspell-trie-lib": "8.8.3",
+        "@cspell/cspell-pipe": "8.8.4",
+        "@cspell/cspell-types": "8.8.4",
+        "cspell-trie-lib": "8.8.4",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0"
       },
@@ -6652,12 +6652,12 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.8.3.tgz",
-      "integrity": "sha512-+IeVPNnUJOj+D9rc4elbK4DK3p9qxvF/2BMtFsE7a75egeJjAnlzVGzqH2FVMsDj6dxe5bjc8/S4Nhw6B14xTQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.8.4.tgz",
+      "integrity": "sha512-rLdxpBh0kp0scwqNBZaWVnxEVmSK3UWyVSZmyEL4jmmjusHYM9IggfedOhO4EfGCIdQ32j21TevE0tTslyc4iA==",
       "dev": true,
       "dependencies": {
-        "cspell-glob": "8.8.3",
+        "cspell-glob": "8.8.4",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -6668,9 +6668,9 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.3.tgz",
-      "integrity": "sha512-9c4Nw/bIsjKSuBuRrLa1sWtIzbXXvja+FVbUOE9c2IiZfh6K1I+UssiXTbRTMg6qgTdkfT4o3KOcFN0ZcbmCUQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.4.tgz",
+      "integrity": "sha512-+tRrOfTSbF/44uNl4idMZVPNfNM6WTmra4ZL44nx23iw1ikNhqZ+m0PC1oCVSlURNBEn8faFXjC/oT2BfgxoUQ==",
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.7"
@@ -6680,13 +6680,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.3.tgz",
-      "integrity": "sha512-3RP7xQ/6IiIjbWQDuE+4b0ERKkSWGMY75bd0oEsh5HcFhhOYphmcpxLxRRM/yxYQaYgdvq0QIcwrpanx86KJ7A==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.4.tgz",
+      "integrity": "sha512-UxDO517iW6vs/8l4OhLpdMR7Bp+tkquvtld1gWz8WYQiDwORyf0v5a3nMh4ILYZGoolOSnDuI9UjWOLI6L/vvQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.3",
-        "@cspell/cspell-types": "8.8.3"
+        "@cspell/cspell-pipe": "8.8.4",
+        "@cspell/cspell-types": "8.8.4"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -6696,37 +6696,37 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.3.tgz",
-      "integrity": "sha512-vO7BUa6i7tjmQr+9dw/Ic7tm4ECnSUlbuMv0zJs/SIrO9AcID2pCWPeZNZEGAmeutrEOi2iThZ/uS33aCuv7Jw==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.4.tgz",
+      "integrity": "sha512-aqB/QMx+xns46QSyPEqi05uguCSxvqRnh2S/ZOhhjPlKma/7hK9niPRcwKwJXJEtNzdiZZkkC1uZt9aJe/7FTA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.8.3"
+        "@cspell/cspell-service-bus": "8.8.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.3.tgz",
-      "integrity": "sha512-IqtTKBPug5Jzt9T8f/b6qGAbARRR5tpQkLjzsrfLzxM68ery23wEPDtmWToEyc9EslulZGLe0T78XuEU9AMF+g==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.4.tgz",
+      "integrity": "sha512-hK8gYtdQ9Lh86c8cEHITt5SaoJbfvXoY/wtpR4k393YR+eAxKziyv8ihQyFE/Z/FwuqtNvDrSntP9NLwTivd3g==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.8.3",
-        "@cspell/cspell-pipe": "8.8.3",
-        "@cspell/cspell-resolver": "8.8.3",
-        "@cspell/cspell-types": "8.8.3",
-        "@cspell/dynamic-import": "8.8.3",
-        "@cspell/strong-weak-map": "8.8.3",
+        "@cspell/cspell-bundled-dicts": "8.8.4",
+        "@cspell/cspell-pipe": "8.8.4",
+        "@cspell/cspell-resolver": "8.8.4",
+        "@cspell/cspell-types": "8.8.4",
+        "@cspell/dynamic-import": "8.8.4",
+        "@cspell/strong-weak-map": "8.8.4",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.3",
-        "cspell-config-lib": "8.8.3",
-        "cspell-dictionary": "8.8.3",
-        "cspell-glob": "8.8.3",
-        "cspell-grammar": "8.8.3",
-        "cspell-io": "8.8.3",
-        "cspell-trie-lib": "8.8.3",
+        "cspell-config-lib": "8.8.4",
+        "cspell-dictionary": "8.8.4",
+        "cspell-glob": "8.8.4",
+        "cspell-grammar": "8.8.4",
+        "cspell-io": "8.8.4",
+        "cspell-trie-lib": "8.8.4",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -6753,13 +6753,13 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.8.3",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.3.tgz",
-      "integrity": "sha512-0zrkrhrFLVajwo6++XD9a+r0Olml7UjPgbztjPKbXIJrZCradBF5rvt3wq5mPpsjq2+Dz0z6K5muZpbO+gqapQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.4.tgz",
+      "integrity": "sha512-yCld4ZL+pFa5DL+Arfvmkv3cCQUOfdRlxElOzdkRZqWyO6h/UmO8xZb21ixVYHiqhJGZmwc3BG9Xuw4go+RLig==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.3",
-        "@cspell/cspell-types": "8.8.3",
+        "@cspell/cspell-pipe": "8.8.4",
+        "@cspell/cspell-types": "8.8.4",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -7918,9 +7918,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
-      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
+      "version": "28.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
+      "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
@@ -7943,9 +7943,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "48.2.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.7.tgz",
-      "integrity": "sha512-fYj3roTnkFL9OFFTB129rico8lerC5G8Vp2ZW9SjO9RNWG0exVvI+i/Y8Bpm1ufjR0uvT38xtoab/U0Hp8Ybog==",
+      "version": "48.2.12",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.12.tgz",
+      "integrity": "sha512-sO9sKkJx5ovWoRk9hV0YiNzXQ4Z6j27CqE/po2E3wddZVuy9wvKPSTiIhpxMTrP/qURvKayJIDB2+o9kyCW1Fw==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.43.1",
@@ -15309,9 +15309,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -19153,9 +19153,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
-      "integrity": "sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -114,13 +114,13 @@
   },
   "devDependencies": {
     "changelog-light": "^1.2.0",
-    "cspell": "^8.8.3",
+    "cspell": "^8.8.4",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jest": "^28.5.0",
-    "eslint-plugin-jsdoc": "^48.2.7",
+    "eslint-plugin-jest": "^28.6.0",
+    "eslint-plugin-jsdoc": "^48.2.12",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
@@ -128,6 +128,6 @@
     "lodash": "^4.17.21",
     "npm-check-updates": "^16.14.20",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.3.0"
+    "prettier": "^3.3.2"
   }
 }


### PR DESCRIPTION

## What's included
<!-- List your changes/additions, or commits -->
- build(deps-dev): bump group with 4 updates
   * cspell from 8.8.3 to 8.8.4
   * eslint-plugin-jest from 28.5.0 to 28.6.0
   * eslint-plugin-jsdoc from 48.2.7 to 48.2.12
   * prettier from 3.3.0 to 3.3.2

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing