### PR TITLE
refactor(standalone): allow functionality breakout

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "ecmaVersion": 2022
   },
   "globals": {
+    "cleanConfigurationPaths": "readonly",
     "fixturePath": "readonly",
     "generateFixture": "readonly",
     "mockObjectProperty": "readonly",

--- a/jest.setupTests.js
+++ b/jest.setupTests.js
@@ -1,6 +1,7 @@
 const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = require('fs');
 const crypto = require('crypto');
 const { extname, join, resolve } = require('path');
+const packageJson = require('./package.json');
 
 jest.mock('child_process', () => ({
   ...jest.requireActual('child_process'),
@@ -135,3 +136,26 @@ const mockObjectProperty = (object = {}, propertiesValues) => {
 };
 
 global.mockObjectProperty = mockObjectProperty;
+
+/**
+ * Provide a consistent way of processing configs.
+ *
+ * @param {*} value
+ * @param {object} options
+ * @param {boolean} options.isHash
+ * @param {string} options.projectName
+ * @returns {string}
+ */
+const cleanConfigurationPaths = (value, { isHash = false, projectName = packageJson.name } = {}) => {
+  const contents = JSON.stringify([(typeof value === 'function' && value.toString()) || value], null, 2).replace(
+    new RegExp(`"[a-z0-9/-_.,*()\\s]*\\/${projectName}\\/`, 'gi'),
+    '"./'
+  );
+  if (isHash) {
+    return crypto.createHash('md5').update(contents).digest('hex');
+  }
+
+  return contents;
+};
+
+global.cleanConfigurationPaths = cleanConfigurationPaths;

--- a/src/README.md
+++ b/src/README.md
@@ -70,7 +70,7 @@ For use with webpack configurations. Set up multiple webpack dotenv file paramet
 <tr>
     <td>params</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>[params.directory]</td><td><code>string</code></td><td><code>&quot;&lt;contextPath&gt;&quot;</code></td>
+    <td>[params.directory]</td><td><code>string</code></td><td><code>&quot;&lt;OPTIONS.contextPath&gt;&quot;</code></td>
     </tr><tr>
     <td>params.env</td><td><code>string</code></td><td></td>
     </tr>  </tbody>
@@ -131,7 +131,7 @@ dotenv parameters are string based, failed or missing dotenv parameters return a
     </tr><tr>
     <td>params.env</td><td><code>string</code></td><td></td><td></td>
     </tr><tr>
-    <td>[params.relativePath]</td><td><code>string</code></td><td><code>&quot;&lt;contextPath&gt;&quot;</code></td><td></td>
+    <td>[params.relativePath]</td><td><code>string</code></td><td><code>&quot;&lt;OPTIONS.contextPath&gt;&quot;</code></td><td></td>
     </tr><tr>
     <td>[params.dotenvNamePrefix]</td><td><code>string</code></td><td><code>&quot;BUILD&quot;</code></td><td><p>Add an internal prefix to dotenv parameters used for configuration to avoid overlap.</p>
 </td>
@@ -324,30 +324,33 @@ Create, or merge, a tsconfig file.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Description</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>dotenv</td><td><code>object</code></td>
+    <td>dotenv</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>dotenv._BUILD_DIST_DIR</td><td><code>string</code></td>
+    <td>dotenv._BUILD_DIST_DIR</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>options</td><td><code>object</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options.baseTsConfig</td><td><code>string</code></td>
+    <td>options.baseTsConfig</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>options.contextPath</td><td><code>string</code></td>
+    <td>options.contextPath</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>options.isCreateTsConfig</td><td><code>boolean</code></td>
+    <td>options.isCreateTsConfig</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>options.isMergeTsConfig</td><td><code>boolean</code></td>
+    <td>options.isMergeTsConfig</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>options.isRegenTsConfig</td><td><code>boolean</code></td>
+    <td>options.isRegenTsConfig</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>settings</td><td><code>object</code></td>
+    <td>settings</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>settings.configFilename</td><td><code>string</code></td>
+    <td>settings.configFilename</td><td><code>string</code></td><td></td>
+    </tr><tr>
+    <td>settings.isMessaging</td><td><code>boolean</code></td><td><p>Helps with standalone configuration</p>
+</td>
     </tr>  </tbody>
 </table>
 
@@ -468,15 +471,18 @@ Start webpack development or production.
 ## webpackConfigs
 
 * [webpackConfigs](#module_webpackConfigs)
-    * [~preprocessLoader(dotenv, options)](#module_webpackConfigs..preprocessLoader) ⇒ <code>Object</code>
+    * [~preprocessLoaderJs(dotenv)](#module_webpackConfigs..preprocessLoaderJs) ⇒ <code>Object</code>
+    * [~preprocessLoaderTs(dotenv)](#module_webpackConfigs..preprocessLoaderTs) ⇒ <code>Object</code>
+    * [~preprocessLoaderNone()](#module_webpackConfigs..preprocessLoaderNone) ⇒ <code>Object</code>
+    * [~preprocessLoader(options)](#module_webpackConfigs..preprocessLoader) ⇒ <code>Object</code>
     * [~common(dotenv)](#module_webpackConfigs..common) ⇒ <code>Object</code>
     * [~development(dotenv)](#module_webpackConfigs..development) ⇒ <code>Object</code>
     * [~production(dotenv)](#module_webpackConfigs..production) ⇒ <code>Object</code>
 
-<a name="module_webpackConfigs..preprocessLoader"></a>
+<a name="module_webpackConfigs..preprocessLoaderJs"></a>
 
-### webpackConfigs~preprocessLoader(dotenv, options) ⇒ <code>Object</code>
-Assumption based preprocess loader
+### webpackConfigs~preprocessLoaderJs(dotenv) ⇒ <code>Object</code>
+Assumption based preprocess loader for JS
 
 **Kind**: inner method of [<code>webpackConfigs</code>](#module_webpackConfigs)  
 <table>
@@ -490,7 +496,49 @@ Assumption based preprocess loader
     <td>dotenv</td><td><code>object</code></td>
     </tr><tr>
     <td>dotenv._BUILD_SRC_DIR</td><td><code>string</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="module_webpackConfigs..preprocessLoaderTs"></a>
+
+### webpackConfigs~preprocessLoaderTs(dotenv) ⇒ <code>Object</code>
+Assumption based preprocess loader for Typescript
+
+**Kind**: inner method of [<code>webpackConfigs</code>](#module_webpackConfigs)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>dotenv</td><td><code>object</code></td>
     </tr><tr>
+    <td>dotenv._BUILD_SRC_DIR</td><td><code>string</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="module_webpackConfigs..preprocessLoaderNone"></a>
+
+### webpackConfigs~preprocessLoaderNone() ⇒ <code>Object</code>
+Assumption based preprocess loader for none
+
+**Kind**: inner method of [<code>webpackConfigs</code>](#module_webpackConfigs)  
+<a name="module_webpackConfigs..preprocessLoader"></a>
+
+### webpackConfigs~preprocessLoader(options) ⇒ <code>Object</code>
+Assumption based preprocess loader
+
+**Kind**: inner method of [<code>webpackConfigs</code>](#module_webpackConfigs)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
     <td>options</td><td><code>object</code></td>
     </tr><tr>
     <td>options.loader</td><td><code>string</code></td>

--- a/src/__tests__/__snapshots__/wp.test.js.snap
+++ b/src/__tests__/__snapshots__/wp.test.js.snap
@@ -2,385 +2,378 @@
 
 exports[`webpack should create a basic webpack config: basic configurations 1`] = `
 {
-  "dev": "{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  },
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
-    "host": "localhost",
-    "port": 3000,
-    "compress": true,
-    "historyApiFallback": true,
-    "hot": true,
-    "devMiddleware": {
-      "stats": "errors-warnings",
-      "writeToDisk": false
-    },
-    "client": {
-      "overlay": false,
-      "progress": true
-    },
-    "static": {
-      "directory": "./__fixtures__/dist"
-    },
-    "watchFiles": {
-      "paths": [
-        "src/**/*"
+  "dev": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
       ]
-    }
-  }
-}",
-  "prod": "{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].[contenthash:8].js",
-    "path": "./__fixtures__/dist",
-    "clean": true,
-    "chunkFilename": "[name].[contenthash:8].chunk.js"
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
           }
         },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].[contenthash:8].css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].[contenthash:8].chunk.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  },
-  "mode": "development",
-  "optimization": {
-    "minimize": true,
-    "minimizer": [
-      {
-        "options": {
+        {
           "test": {},
-          "extractComments": true,
-          "parallel": true,
-          "minimizer": {
-            "options": {}
-          }
-        }
-      },
-      {
-        "options": {
-          "test": {},
-          "parallel": true,
-          "minimizer": {
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false
-                }
-              ]
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
             }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
           }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].bundle.css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].bundle.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
         }
       }
     ],
-    "runtimeChunk": "single",
-    "splitChunks": {
-      "chunks": "all",
-      "cacheGroups": {
-        "vendor": {
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    },
+    "mode": "development",
+    "devtool": "eval-source-map",
+    "devServer": {
+      "host": "localhost",
+      "port": 3000,
+      "compress": true,
+      "historyApiFallback": true,
+      "hot": true,
+      "devMiddleware": {
+        "stats": "errors-warnings",
+        "writeToDisk": false
+      },
+      "client": {
+        "overlay": false,
+        "progress": true
+      },
+      "static": {
+        "directory": "./__fixtures__/dist"
+      },
+      "watchFiles": {
+        "paths": [
+          "src/**/*"
+        ]
+      }
+    }
+  }
+]",
+  "prod": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].[contenthash:8].js",
+      "path": "./__fixtures__/dist",
+      "clean": true,
+      "chunkFilename": "[name].[contenthash:8].chunk.js"
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
           "chunks": "all",
-          "name": "vendor",
-          "test": {}
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].[contenthash:8].css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].[contenthash:8].chunk.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    },
+    "mode": "development",
+    "optimization": {
+      "minimize": true,
+      "minimizer": [
+        {
+          "options": {
+            "test": {},
+            "extractComments": true,
+            "parallel": true,
+            "minimizer": {
+              "options": {}
+            }
+          }
+        },
+        {
+          "options": {
+            "test": {},
+            "parallel": true,
+            "minimizer": {
+              "options": {
+                "preset": [
+                  "default",
+                  {
+                    "mergeLonghand": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "runtimeChunk": "single",
+      "splitChunks": {
+        "chunks": "all",
+        "cacheGroups": {
+          "vendor": {
+            "chunks": "all",
+            "name": "vendor",
+            "test": {}
+          }
         }
       }
     }
   }
-}",
+]",
 }
 `;
 
 exports[`webpack should create a webpack config with language: language configurations 1`] = `
 {
-  "dev": "{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
+  "js": "[
+  {
     "rules": [
       {
         "test": {},
@@ -445,138 +438,10 @@ exports[`webpack should create a webpack config with language: language configur
         ]
       }
     ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  },
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
-    "host": "localhost",
-    "port": 3000,
-    "compress": true,
-    "historyApiFallback": true,
-    "hot": true,
-    "devMiddleware": {
-      "stats": "errors-warnings",
-      "writeToDisk": false
-    },
-    "client": {
-      "overlay": false,
-      "progress": true
-    },
-    "static": {
-      "directory": "./__fixtures__/dist"
-    },
-    "watchFiles": {
-      "paths": [
-        "src/**/*"
-      ]
-    }
   }
-}",
-  "prod": "{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].[contenthash:8].js",
-    "path": "./__fixtures__/dist",
-    "clean": true,
-    "chunkFilename": "[name].[contenthash:8].chunk.js"
-  },
-  "module": {
+]",
+  "ts": "[
+  {
     "rules": [
       {
         "test": {},
@@ -623,6 +488,10 @@ exports[`webpack should create a webpack config with language: language configur
         ],
         "resolve": {
           "extensions": [
+            ".ts",
+            ".tsx",
+            ".mts",
+            ".cts",
             ".js",
             ".jsx",
             ".mjs",
@@ -631,305 +500,19 @@ exports[`webpack should create a webpack config with language: language configur
         },
         "use": [
           {
-            "loader": "babel-loader",
-            "options": {
-              "presets": [
-                "@babel/preset-env"
-              ]
-            }
+            "loader": "ts-loader"
           }
         ]
       }
     ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].[contenthash:8].css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].[contenthash:8].chunk.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  },
-  "mode": "development",
-  "optimization": {
-    "minimize": true,
-    "minimizer": [
-      {
-        "options": {
-          "test": {},
-          "extractComments": true,
-          "parallel": true,
-          "minimizer": {
-            "options": {}
-          }
-        }
-      },
-      {
-        "options": {
-          "test": {},
-          "parallel": true,
-          "minimizer": {
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false
-                }
-              ]
-            }
-          }
-        }
-      }
-    ],
-    "runtimeChunk": "single",
-    "splitChunks": {
-      "chunks": "all",
-      "cacheGroups": {
-        "vendor": {
-          "chunks": "all",
-          "name": "vendor",
-          "test": {}
-        }
-      }
-    }
   }
-}",
+]",
 }
 `;
 
-exports[`webpack should extend a basic webpack config using commonJS resources: configurations 1`] = `
-{
-  "common": "{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  },
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
+exports[`webpack should extend a basic webpack config using external resources: custom configurations 1`] = `
+"[
+  {
     "host": "localhost",
     "port": 3000,
     "compress": true,
@@ -952,8 +535,7 @@ exports[`webpack should extend a basic webpack config using commonJS resources: 
       ]
     }
   }
-}",
-}
+]"
 `;
 
 exports[`webpack should handle build output bundle errors, stats errors, and stat output: startWpErrorStatsHandler 1`] = `

--- a/src/__tests__/__snapshots__/wpConfigs.test.js.snap
+++ b/src/__tests__/__snapshots__/wpConfigs.test.js.snap
@@ -1,1005 +1,1345 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webpackConfigs should return a common configuration object: common dev, prod hashes 1`] = `
+exports[`webpackConfigs should return a common configuration object: common dev and prod hashes, code snapshots 1`] = `
 [
   {
-    "devHash": "09dbe6c79e6e659a16607250a6517521",
-    "isEqual": true,
-    "loader": "js",
-    "prodHash": "09dbe6c79e6e659a16607250a6517521",
-  },
+    "devSnapshot": "[
   {
-    "devHash": "09dbe6c79e6e659a16607250a6517521",
-    "isEqual": true,
-    "loader": "ts",
-    "prodHash": "09dbe6c79e6e659a16607250a6517521",
-  },
-  {
-    "devHash": "09dbe6c79e6e659a16607250a6517521",
-    "isEqual": true,
-    "loader": "none",
-    "prodHash": "09dbe6c79e6e659a16607250a6517521",
-  },
-]
-`;
-
-exports[`webpackConfigs should return a common configuration object: common dev: js 1`] = `
-"{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  }
-}"
-`;
-
-exports[`webpackConfigs should return a common configuration object: common dev: none 1`] = `
-"{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  }
-}"
-`;
-
-exports[`webpackConfigs should return a common configuration object: common dev: ts 1`] = `
-"{
-  "context": "./__fixtures__",
-  "entry": {
-    "app": [
-      "./__fixtures__/src/index.js"
-    ]
-  },
-  "output": {
-    "filename": "[name].bundle.js",
-    "path": "./__fixtures__/dist",
-    "clean": true
-  },
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "type": "asset/resource",
-        "generator": {
-          "filename": "fonts/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "type": "asset",
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 5000
-          }
-        },
-        "generator": {
-          "filename": "images/[hash][ext][query]"
-        }
-      },
-      {
-        "test": {},
-        "use": [
-          "./node_modules/mini-css-extract-plugin/dist/loader.js",
-          "css-loader"
-        ]
-      }
-    ]
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "userOptions": {},
-      "version": 5,
-      "options": {
-        "template": "auto",
-        "templateContent": false,
-        "filename": "index.html",
-        "publicPath": "auto",
-        "hash": false,
-        "inject": "head",
-        "scriptLoading": "defer",
-        "compile": true,
-        "favicon": false,
-        "minify": "auto",
-        "cache": true,
-        "showErrors": true,
-        "chunks": "all",
-        "excludeChunks": [],
-        "chunksSortMode": "auto",
-        "meta": {},
-        "base": false,
-        "title": "Webpack App",
-        "xhtml": false
-      }
-    }
-  ],
-  "resolve": {
-    "symlinks": false,
-    "cacheWithContext": false
-  }
-}"
-`;
-
-exports[`webpackConfigs should return a development configuration object: development dev, prod hashes 1`] = `
-[
-  {
-    "devHash": "1513dc6a6f52f8e842db469aef46217a",
-    "isEqual": false,
-    "loader": "js",
-    "prodHash": "224f0decf8a5de38b60d8e7efc30a6a1",
-  },
-  {
-    "devHash": "1513dc6a6f52f8e842db469aef46217a",
-    "isEqual": false,
-    "loader": "ts",
-    "prodHash": "224f0decf8a5de38b60d8e7efc30a6a1",
-  },
-  {
-    "devHash": "1513dc6a6f52f8e842db469aef46217a",
-    "isEqual": false,
-    "loader": "none",
-    "prodHash": "224f0decf8a5de38b60d8e7efc30a6a1",
-  },
-]
-`;
-
-exports[`webpackConfigs should return a development configuration object: development dev: js 1`] = `
-"{
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
-    "host": "localhost",
-    "port": 3000,
-    "compress": true,
-    "historyApiFallback": true,
-    "hot": true,
-    "devMiddleware": {
-      "stats": "errors-warnings",
-      "writeToDisk": false
-    },
-    "client": {
-      "overlay": false,
-      "progress": true
-    },
-    "static": {
-      "directory": "./__fixtures__/dist"
-    },
-    "watchFiles": {
-      "paths": [
-        "src/**/*"
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
       ]
-    }
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
     },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
     },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ]
-}"
-`;
-
-exports[`webpackConfigs should return a development configuration object: development dev: none 1`] = `
-"{
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
-    "host": "localhost",
-    "port": 3000,
-    "compress": true,
-    "historyApiFallback": true,
-    "hot": true,
-    "devMiddleware": {
-      "stats": "errors-warnings",
-      "writeToDisk": false
-    },
-    "client": {
-      "overlay": false,
-      "progress": true
-    },
-    "static": {
-      "directory": "./__fixtures__/dist"
-    },
-    "watchFiles": {
-      "paths": [
-        "src/**/*"
-      ]
-    }
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ]
-}"
-`;
-
-exports[`webpackConfigs should return a development configuration object: development dev: ts 1`] = `
-"{
-  "mode": "development",
-  "devtool": "eval-source-map",
-  "devServer": {
-    "host": "localhost",
-    "port": 3000,
-    "compress": true,
-    "historyApiFallback": true,
-    "hot": true,
-    "devMiddleware": {
-      "stats": "errors-warnings",
-      "writeToDisk": false
-    },
-    "client": {
-      "overlay": false,
-      "progress": true
-    },
-    "static": {
-      "directory": "./__fixtures__/dist"
-    },
-    "watchFiles": {
-      "paths": [
-        "src/**/*"
-      ]
-    }
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].bundle.css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].bundle.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
-    }
-  ]
-}"
-`;
-
-exports[`webpackConfigs should return a preprocessLoader configuration object: language dev, prod hashes 1`] = `
-[
-  {
-    "devHash": "b1a27bfb44b6063a2a599931989a64f8",
-    "isEqual": true,
-    "loader": "js",
-    "prodHash": "b1a27bfb44b6063a2a599931989a64f8",
-  },
-  {
-    "devHash": "6cf8d288bb31e0a6e6c97b9d54e0c192",
-    "isEqual": true,
-    "loader": "ts",
-    "prodHash": "6cf8d288bb31e0a6e6c97b9d54e0c192",
-  },
-  {
-    "devHash": "49e595be76828acf4f2a3617fea9a378",
-    "isEqual": true,
-    "loader": "none",
-    "prodHash": "49e595be76828acf4f2a3617fea9a378",
-  },
-]
-`;
-
-exports[`webpackConfigs should return a preprocessLoader configuration object: preprocessLoader dev: js 1`] = `
-"{
-  "module": {
-    "rules": [
-      {
-        "test": {},
-        "include": [
-          "./__fixtures__/src"
-        ],
-        "resolve": {
-          "extensions": [
-            ".js",
-            ".jsx",
-            ".mjs",
-            ".cjs"
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
           ]
-        },
-        "use": [
-          {
-            "loader": "babel-loader",
-            "options": {
-              "presets": [
-                "@babel/preset-env"
-              ]
-            }
-          }
-        ]
-      }
-    ]
-  }
-}"
-`;
-
-exports[`webpackConfigs should return a preprocessLoader configuration object: preprocessLoader dev: none 1`] = `
-"{
-  "module": {
-    "rules": []
-  }
-}"
-`;
-
-exports[`webpackConfigs should return a preprocessLoader configuration object: preprocessLoader dev: ts 1`] = `
-"{
-  "module": {
-    "rules": [
+        }
+      ]
+    },
+    "plugins": [
       {
-        "test": {},
-        "include": [
-          "./__fixtures__/src"
-        ],
-        "resolve": {
-          "extensions": [
-            ".ts",
-            ".tsx",
-            ".mts",
-            ".cts",
-            ".js",
-            ".jsx",
-            ".mjs",
-            ".cjs"
-          ]
-        },
-        "use": [
-          {
-            "loader": "ts-loader"
-          }
-        ]
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
       }
-    ]
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
   }
-}"
-`;
-
-exports[`webpackConfigs should return a production configuration object: production dev, prod hashes 1`] = `
-[
-  {
-    "devHash": "9538aadb737ec81df9a67275a1d4e93f",
-    "isEqual": false,
+]",
     "loader": "js",
-    "prodHash": "4635888960b8aaecc46599deb39c005e",
+    "prodSnapshot": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
+  }
+]",
   },
   {
-    "devHash": "9538aadb737ec81df9a67275a1d4e93f",
-    "isEqual": false,
+    "devSnapshot": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
+  }
+]",
     "loader": "ts",
-    "prodHash": "4635888960b8aaecc46599deb39c005e",
+    "prodSnapshot": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
+  }
+]",
   },
   {
-    "devHash": "9538aadb737ec81df9a67275a1d4e93f",
-    "isEqual": false,
+    "devSnapshot": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
+  }
+]",
     "loader": "none",
-    "prodHash": "4635888960b8aaecc46599deb39c005e",
+    "prodSnapshot": "[
+  {
+    "context": "./__fixtures__",
+    "entry": {
+      "app": [
+        "./__fixtures__/src/index.js"
+      ]
+    },
+    "output": {
+      "filename": "[name].bundle.js",
+      "path": "./__fixtures__/dist",
+      "clean": true
+    },
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "type": "asset/resource",
+          "generator": {
+            "filename": "fonts/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "type": "asset",
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 5000
+            }
+          },
+          "generator": {
+            "filename": "images/[hash][ext][query]"
+          }
+        },
+        {
+          "test": {},
+          "use": [
+            "./node_modules/mini-css-extract-plugin/dist/loader.js",
+            "css-loader"
+          ]
+        }
+      ]
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "userOptions": {},
+        "version": 5,
+        "options": {
+          "template": "auto",
+          "templateContent": false,
+          "filename": "index.html",
+          "publicPath": "auto",
+          "hash": false,
+          "inject": "head",
+          "scriptLoading": "defer",
+          "compile": true,
+          "favicon": false,
+          "minify": "auto",
+          "cache": true,
+          "showErrors": true,
+          "chunks": "all",
+          "excludeChunks": [],
+          "chunksSortMode": "auto",
+          "meta": {},
+          "base": false,
+          "title": "Webpack App",
+          "xhtml": false
+        }
+      }
+    ],
+    "resolve": {
+      "symlinks": false,
+      "cacheWithContext": false
+    }
+  }
+]",
   },
 ]
 `;
 
-exports[`webpackConfigs should return a production configuration object: production dev: js 1`] = `
-"{
-  "mode": "development",
-  "output": {
-    "chunkFilename": "[name].[contenthash:8].chunk.js",
-    "filename": "[name].[contenthash:8].js"
-  },
-  "optimization": {
-    "minimize": true,
-    "minimizer": [
+exports[`webpackConfigs should return a development configuration object: development dev hashes, code snapshots 1`] = `
+[
+  {
+    "devSnapshot": "[
+  {
+    "mode": "development",
+    "devtool": "eval-source-map",
+    "devServer": {
+      "host": "localhost",
+      "port": 3000,
+      "compress": true,
+      "historyApiFallback": true,
+      "hot": true,
+      "devMiddleware": {
+        "stats": "errors-warnings",
+        "writeToDisk": false
+      },
+      "client": {
+        "overlay": false,
+        "progress": true
+      },
+      "static": {
+        "directory": "./__fixtures__/dist"
+      },
+      "watchFiles": {
+        "paths": [
+          "src/**/*"
+        ]
+      }
+    },
+    "plugins": [
       {
-        "options": {
-          "test": {},
-          "extractComments": true,
-          "parallel": true,
-          "minimizer": {
-            "options": {}
-          }
+        "config": {
+          "path": "./__fixtures__/.env.development.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
         }
       },
       {
-        "options": {
-          "test": {},
-          "parallel": true,
-          "minimizer": {
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false
-                }
-              ]
-            }
-          }
+        "config": {
+          "path": "./__fixtures__/.env.development",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
         }
-      }
-    ],
-    "runtimeChunk": "single",
-    "splitChunks": {
-      "chunks": "all",
-      "cacheGroups": {
-        "vendor": {
-          "chunks": "all",
-          "name": "vendor",
-          "test": {}
-        }
-      }
-    }
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].[contenthash:8].css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].[contenthash:8].chunk.css"
       },
-      "runtimeOptions": {
-        "linkType": "text/css"
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].bundle.css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].bundle.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
       }
-    }
-  ]
-}"
+    ]
+  }
+]",
+    "loader": "js",
+    "prodSnapshot": undefined,
+  },
+  {
+    "devSnapshot": "[
+  {
+    "mode": "development",
+    "devtool": "eval-source-map",
+    "devServer": {
+      "host": "localhost",
+      "port": 3000,
+      "compress": true,
+      "historyApiFallback": true,
+      "hot": true,
+      "devMiddleware": {
+        "stats": "errors-warnings",
+        "writeToDisk": false
+      },
+      "client": {
+        "overlay": false,
+        "progress": true
+      },
+      "static": {
+        "directory": "./__fixtures__/dist"
+      },
+      "watchFiles": {
+        "paths": [
+          "src/**/*"
+        ]
+      }
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].bundle.css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].bundle.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
+      }
+    ]
+  }
+]",
+    "loader": "ts",
+    "prodSnapshot": undefined,
+  },
+  {
+    "devSnapshot": "[
+  {
+    "mode": "development",
+    "devtool": "eval-source-map",
+    "devServer": {
+      "host": "localhost",
+      "port": 3000,
+      "compress": true,
+      "historyApiFallback": true,
+      "hot": true,
+      "devMiddleware": {
+        "stats": "errors-warnings",
+        "writeToDisk": false
+      },
+      "client": {
+        "overlay": false,
+        "progress": true
+      },
+      "static": {
+        "directory": "./__fixtures__/dist"
+      },
+      "watchFiles": {
+        "paths": [
+          "src/**/*"
+        ]
+      }
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.development",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].bundle.css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].bundle.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
+      }
+    ]
+  }
+]",
+    "loader": "none",
+    "prodSnapshot": undefined,
+  },
+]
 `;
 
-exports[`webpackConfigs should return a production configuration object: production dev: none 1`] = `
-"{
-  "mode": "development",
-  "output": {
-    "chunkFilename": "[name].[contenthash:8].chunk.js",
-    "filename": "[name].[contenthash:8].js"
-  },
-  "optimization": {
-    "minimize": true,
-    "minimizer": [
-      {
-        "options": {
+exports[`webpackConfigs should return a preprocessLoader configuration object: language dev and prod hashes, code snapshots 1`] = `
+[
+  {
+    "devSnapshot": "[
+  {
+    "module": {
+      "rules": [
+        {
           "test": {},
-          "extractComments": true,
-          "parallel": true,
-          "minimizer": {
-            "options": {}
-          }
-        }
-      },
-      {
-        "options": {
-          "test": {},
-          "parallel": true,
-          "minimizer": {
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false
-                }
-              ]
+          "include": [
+            "./__fixtures__/src"
+          ],
+          "resolve": {
+            "extensions": [
+              ".js",
+              ".jsx",
+              ".mjs",
+              ".cjs"
+            ]
+          },
+          "use": [
+            {
+              "loader": "babel-loader",
+              "options": {
+                "presets": [
+                  "@babel/preset-env"
+                ]
+              }
             }
-          }
+          ]
         }
-      }
-    ],
-    "runtimeChunk": "single",
-    "splitChunks": {
-      "chunks": "all",
-      "cacheGroups": {
-        "vendor": {
-          "chunks": "all",
-          "name": "vendor",
-          "test": {}
-        }
-      }
+      ]
     }
+  }
+]",
+    "loader": "js",
+    "prodSnapshot": "[
+  {
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "include": [
+            "./__fixtures__/src"
+          ],
+          "resolve": {
+            "extensions": [
+              ".js",
+              ".jsx",
+              ".mjs",
+              ".cjs"
+            ]
+          },
+          "use": [
+            {
+              "loader": "babel-loader",
+              "options": {
+                "presets": [
+                  "@babel/preset-env"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+]",
   },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].[contenthash:8].css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].[contenthash:8].chunk.css"
-      },
-      "runtimeOptions": {
-        "linkType": "text/css"
-      }
+  {
+    "devSnapshot": "[
+  {
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "include": [
+            "./__fixtures__/src"
+          ],
+          "resolve": {
+            "extensions": [
+              ".ts",
+              ".tsx",
+              ".mts",
+              ".cts",
+              ".js",
+              ".jsx",
+              ".mjs",
+              ".cjs"
+            ]
+          },
+          "use": [
+            {
+              "loader": "ts-loader"
+            }
+          ]
+        }
+      ]
     }
-  ]
-}"
+  }
+]",
+    "loader": "ts",
+    "prodSnapshot": "[
+  {
+    "module": {
+      "rules": [
+        {
+          "test": {},
+          "include": [
+            "./__fixtures__/src"
+          ],
+          "resolve": {
+            "extensions": [
+              ".ts",
+              ".tsx",
+              ".mts",
+              ".cts",
+              ".js",
+              ".jsx",
+              ".mjs",
+              ".cjs"
+            ]
+          },
+          "use": [
+            {
+              "loader": "ts-loader"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]",
+  },
+  {
+    "devSnapshot": "[
+  {
+    "module": {
+      "rules": []
+    }
+  }
+]",
+    "loader": "none",
+    "prodSnapshot": "[
+  {
+    "module": {
+      "rules": []
+    }
+  }
+]",
+  },
+]
 `;
 
-exports[`webpackConfigs should return a production configuration object: production dev: ts 1`] = `
-"{
-  "mode": "development",
-  "output": {
-    "chunkFilename": "[name].[contenthash:8].chunk.js",
-    "filename": "[name].[contenthash:8].js"
-  },
-  "optimization": {
-    "minimize": true,
-    "minimizer": [
-      {
-        "options": {
-          "test": {},
-          "extractComments": true,
-          "parallel": true,
-          "minimizer": {
-            "options": {}
+exports[`webpackConfigs should return a production configuration object: production prod hashes, code snapshots 1`] = `
+[
+  {
+    "devSnapshot": undefined,
+    "loader": "js",
+    "prodSnapshot": "[
+  {
+    "mode": "production",
+    "output": {
+      "chunkFilename": "[name].[contenthash:8].chunk.js",
+      "filename": "[name].[contenthash:8].js"
+    },
+    "optimization": {
+      "minimize": true,
+      "minimizer": [
+        {
+          "options": {
+            "test": {},
+            "extractComments": true,
+            "parallel": true,
+            "minimizer": {
+              "options": {}
+            }
           }
-        }
-      },
-      {
-        "options": {
-          "test": {},
-          "parallel": true,
-          "minimizer": {
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false
-                }
-              ]
+        },
+        {
+          "options": {
+            "test": {},
+            "parallel": true,
+            "minimizer": {
+              "options": {
+                "preset": [
+                  "default",
+                  {
+                    "mergeLonghand": false
+                  }
+                ]
+              }
             }
           }
         }
-      }
-    ],
-    "runtimeChunk": "single",
-    "splitChunks": {
-      "chunks": "all",
-      "cacheGroups": {
-        "vendor": {
-          "chunks": "all",
-          "name": "vendor",
-          "test": {}
+      ],
+      "runtimeChunk": "single",
+      "splitChunks": {
+        "chunks": "all",
+        "cacheGroups": {
+          "vendor": {
+            "chunks": "all",
+            "name": "vendor",
+            "test": {}
+          }
         }
       }
-    }
-  },
-  "plugins": [
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
     },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.development",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env.local",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "config": {
-        "path": "./__fixtures__/.env",
-        "prefix": "process.env.",
-        "systemvars": true,
-        "silent": true
-      }
-    },
-    {
-      "_sortedModulesCache": {},
-      "options": {
-        "filename": "[name].[contenthash:8].css",
-        "ignoreOrder": false,
-        "runtime": true,
-        "chunkFilename": "[name].[contenthash:8].chunk.css"
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
       },
-      "runtimeOptions": {
-        "linkType": "text/css"
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].[contenthash:8].css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].[contenthash:8].chunk.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
       }
-    }
-  ]
-}"
+    ]
+  }
+]",
+  },
+  {
+    "devSnapshot": undefined,
+    "loader": "ts",
+    "prodSnapshot": "[
+  {
+    "mode": "production",
+    "output": {
+      "chunkFilename": "[name].[contenthash:8].chunk.js",
+      "filename": "[name].[contenthash:8].js"
+    },
+    "optimization": {
+      "minimize": true,
+      "minimizer": [
+        {
+          "options": {
+            "test": {},
+            "extractComments": true,
+            "parallel": true,
+            "minimizer": {
+              "options": {}
+            }
+          }
+        },
+        {
+          "options": {
+            "test": {},
+            "parallel": true,
+            "minimizer": {
+              "options": {
+                "preset": [
+                  "default",
+                  {
+                    "mergeLonghand": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "runtimeChunk": "single",
+      "splitChunks": {
+        "chunks": "all",
+        "cacheGroups": {
+          "vendor": {
+            "chunks": "all",
+            "name": "vendor",
+            "test": {}
+          }
+        }
+      }
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].[contenthash:8].css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].[contenthash:8].chunk.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
+      }
+    ]
+  }
+]",
+  },
+  {
+    "devSnapshot": undefined,
+    "loader": "none",
+    "prodSnapshot": "[
+  {
+    "mode": "production",
+    "output": {
+      "chunkFilename": "[name].[contenthash:8].chunk.js",
+      "filename": "[name].[contenthash:8].js"
+    },
+    "optimization": {
+      "minimize": true,
+      "minimizer": [
+        {
+          "options": {
+            "test": {},
+            "extractComments": true,
+            "parallel": true,
+            "minimizer": {
+              "options": {}
+            }
+          }
+        },
+        {
+          "options": {
+            "test": {},
+            "parallel": true,
+            "minimizer": {
+              "options": {
+                "preset": [
+                  "default",
+                  {
+                    "mergeLonghand": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "runtimeChunk": "single",
+      "splitChunks": {
+        "chunks": "all",
+        "cacheGroups": {
+          "vendor": {
+            "chunks": "all",
+            "name": "vendor",
+            "test": {}
+          }
+        }
+      }
+    },
+    "plugins": [
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.production",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env.local",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "config": {
+          "path": "./__fixtures__/.env",
+          "prefix": "process.env.",
+          "systemvars": true,
+          "silent": true
+        }
+      },
+      {
+        "_sortedModulesCache": {},
+        "options": {
+          "filename": "[name].[contenthash:8].css",
+          "ignoreOrder": false,
+          "runtime": true,
+          "chunkFilename": "[name].[contenthash:8].chunk.css"
+        },
+        "runtimeOptions": {
+          "linkType": "text/css"
+        }
+      }
+    ]
+  }
+]",
+  },
+]
 `;
 
 exports[`webpackConfigs should return specific properties: specific properties 1`] = `
@@ -1007,6 +1347,9 @@ exports[`webpackConfigs should return specific properties: specific properties 1
   "common": [Function],
   "development": [Function],
   "preprocessLoader": [Function],
+  "preprocessLoaderJs": [Function],
+  "preprocessLoaderNone": [Function],
+  "preprocessLoaderTs": [Function],
   "production": [Function],
 }
 `;

--- a/src/dotenv.js
+++ b/src/dotenv.js
@@ -2,7 +2,7 @@ const path = require('path');
 const setupDotenv = require('dotenv');
 const { expand: dotenvExpand } = require('dotenv-expand');
 const { consoleMessage } = require('./logger');
-const { contextPath } = require('./global');
+const { OPTIONS } = require('./global');
 
 /**
  * @module dotenv
@@ -25,7 +25,7 @@ const setupWebpackDotenvFile = filePath => {
   }
 
   try {
-    // eslint-disable-next-line global-require
+    // eslint-disable-next-line
     const DotEnv = require('dotenv-webpack');
     return new DotEnv(settings);
   } catch (e) {
@@ -39,11 +39,11 @@ const setupWebpackDotenvFile = filePath => {
  * For use with webpack configurations. Set up multiple webpack dotenv file parameters.
  *
  * @param {object} params
- * @param {string} [params.directory=<contextPath>]
+ * @param {string} [params.directory=<OPTIONS.contextPath>]
  * @param {string} params.env
  * @returns {Array}
  */
-const setupWebpackDotenvFilesForEnv = ({ directory = contextPath, env } = {}) => {
+const setupWebpackDotenvFilesForEnv = ({ directory = OPTIONS.contextPath, env } = {}) => {
   const dotenvWebpackSettings = [];
 
   try {
@@ -93,7 +93,7 @@ const setDotenvParam = (params = []) => {
  *
  * @param {object} params
  * @param {string} params.env
- * @param {string} [params.relativePath=<contextPath>]
+ * @param {string} [params.relativePath=<OPTIONS.contextPath>]
  * @param {string} [params.dotenvNamePrefix=BUILD] Add an internal prefix to dotenv parameters used for configuration to avoid overlap.
  * @param {boolean} [params.setBuildDefaults=true]
  * @param {boolean} [params.isMessaging=false]
@@ -102,7 +102,7 @@ const setDotenvParam = (params = []) => {
  */
 const setupDotenvFilesForEnv = ({
   env,
-  relativePath = contextPath,
+  relativePath = OPTIONS.contextPath,
   dotenvNamePrefix = 'BUILD',
   setBuildDefaults = true,
   isMessaging = false,

--- a/src/ts.js
+++ b/src/ts.js
@@ -20,22 +20,25 @@ const { consoleMessage } = require('./logger');
  * @param {boolean} options.isRegenTsConfig
  * @param {object} settings
  * @param {string} settings.configFilename
+ * @param {boolean} settings.isMessaging Helps with standalone configuration
  * @returns {undefined|{compilerOptions: {noEmit: boolean, allowJs: boolean, outDir: string}}}
  */
 const createTsConfig = (
   { _BUILD_DIST_DIR: DIST_DIR } = OPTIONS.dotenv || {},
   { baseTsConfig, contextPath, isCreateTsConfig, isMergeTsConfig, isRegenTsConfig } = OPTIONS,
-  { configFilename = 'tsconfig.json' } = {}
+  { configFilename = 'tsconfig.json', isMessaging = true } = {}
 ) => {
   const currentConfigPath = path.join(contextPath, configFilename);
   const isCurrentConfig = fs.existsSync(currentConfigPath);
 
-  if (isCurrentConfig) {
-    consoleMessage.warn(`Current ${configFilename} found: ${currentConfigPath}`);
+  if (isCurrentConfig && isMessaging) {
+    consoleMessage.info(`Current ${configFilename} found: ${currentConfigPath}`);
   }
 
   if (!isCreateTsConfig) {
-    consoleMessage.warn(`Ignoring ${configFilename}`);
+    if (isMessaging) {
+      consoleMessage.info(`Ignoring ${configFilename}`);
+    }
     return undefined;
   }
 
@@ -47,7 +50,9 @@ const createTsConfig = (
       // eslint-disable-next-line global-require
       currentConfig = require(currentConfigPath);
     } catch (e) {
-      consoleMessage.warn(`No ${configFilename} found.`);
+      if (isMessaging) {
+        consoleMessage.warn(`No ${configFilename} found.`);
+      }
     }
   }
 
@@ -56,7 +61,9 @@ const createTsConfig = (
       // eslint-disable-next-line global-require
       presetConfig = require(`@tsconfig/${baseTsConfig}/${configFilename}`);
     } catch (e) {
-      consoleMessage.warn(`No preset ${configFilename} specified, using basic properties only.`);
+      if (isMessaging) {
+        consoleMessage.warn(`No preset ${configFilename} specified, using basic properties only.`);
+      }
     }
   }
 
@@ -77,7 +84,7 @@ const createTsConfig = (
     filename: configFilename
   });
 
-  if (isCreateTsConfig) {
+  if (isCreateTsConfig && isMessaging) {
     consoleMessage.success(
       `${(isMergeTsConfig && 'Merged') || (isRegenTsConfig && 'Regenerated') || 'Created'} config: ${path.join(
         contextPath,

--- a/src/wp.js
+++ b/src/wp.js
@@ -121,7 +121,7 @@ const startWpErrorStatsHandler = (err, stats, { stats: statsLevel, statsFile, st
       .join('\n');
 
     consoleMessage.log(
-      `Stats level ${color.YELLOW}${statsLevel}${color.NOCOLOR}...`,
+      `Stats level ${color.YELLOW || ''}${statsLevel}${color.NOCOLOR || ''}...`,
       (formattedStats.trim() === '' && '  No stats output') || formattedStats
     );
   }


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- refactor(standalone): allow functionality breakout
    * dotenv, move to using global options
   * global, add runCmd
   * ts, allow disable messaging
   * wp, minor fallback for no color
   * wpConfigs, move loaders into independent funcs

### Notes
- there should be no change in current behavior
- breakout the standalone commits for sanity

<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing, support for #70 