### PR TITLE
build(nodejs)!: remove 18 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.12.0, 18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal of `weldable` is to make it easier to install `webpack` build packages 
 
 ## Requirements
 The basic requirements:
- * [NodeJS version 18.12.0+](https://nodejs.org/)
+ * [NodeJS version 20+](https://nodejs.org/)
  * NPM
    > There appear to be dependency mapping issues with `Yarn` v1.x.x lock files, `Typescript` and `webpack`, and specific dependencies
    > using ES modules. If you do decide to use [Yarn](https://yarnpkg.com) use the latest version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "prettier": "^3.5.3"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "webpack"
   ],
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- build(nodejs): remove 18 support

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->
- removes support for nodejs 18 with upcoming release, breaking change. minimum package version that can be used with nodejs 18 is v3.2.4
## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
   - confirm integration action covers nodejs 22 and applies 20 as min
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing