### PR TITLE
build(deps): bump copy-webpack-plugin from 13.0.1 to 14.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tsconfig/recommended": "1.0.11",
         "@tsconfig/strictest": "2.0.6",
         "babel-loader": "10.0.0",
-        "copy-webpack-plugin": "13.0.1",
+        "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
         "css-minimizer-webpack-plugin": "7.0.4",
         "dotenv": "16.6.1",
@@ -7458,19 +7458,19 @@
       }
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
-      "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
+      "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
       "license": "MIT",
       "dependencies": {
         "glob-parent": "^6.0.1",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.3",
         "tinyglobby": "^0.2.12"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 20.9.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7478,6 +7478,15 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@tsconfig/recommended": "1.0.11",
     "@tsconfig/strictest": "2.0.6",
     "babel-loader": "10.0.0",
-    "copy-webpack-plugin": "13.0.1",
+    "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
     "css-minimizer-webpack-plugin": "7.0.4",
     "dotenv": "16.6.1",


### PR DESCRIPTION

## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump copy-webpack-plugin from 13.0.1 to 14.0.0

Bumps [copy-webpack-plugin](https://github.com/webpack/copy-webpack-plugin) from 13.0.1 to 14.0.0
- [Release notes](https://github.com/webpack/copy-webpack-plugin/releases)
- [Commits](webpack/copy-webpack-plugin@v13.0.1...v14.0.0)

### Notes
- The resource indicates it is a "breaking update" in that makes the min node version `20.9.0`. Our min version is `20+`. 
   - We may minimally note this in CHANGELOG.md but for most consumers, no one will notice, we do not expect breaking results.
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing